### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/publish_charms.yaml
+++ b/.github/workflows/publish_charms.yaml
@@ -3,7 +3,7 @@ name: Publish charms
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
 
 jobs:
@@ -13,13 +13,16 @@ jobs:
     outputs:
       charm-dirs: ${{ steps.charm-dirs.outputs.charm-dirs }}
     steps:
-      - uses: actions/checkout@v6.0.1
-      - id: charm-dirs
-        run: |
-          echo charm-dirs=`find -name charmcraft.yaml | xargs dirname | jq --raw-input --slurp 'split("\n") | map(select(. != ""))'` >> $GITHUB_OUTPUT
+    - uses: actions/checkout@v6.0.1
+    - id: charm-dirs
+      run: |
+        echo charm-dirs=`find -name charmcraft.yaml | xargs dirname | jq --raw-input --slurp 'split("\n") | map(select(. != ""))'` >> $GITHUB_OUTPUT
 
   publish-charm:
-    needs: [ find-charms ]
+    needs: [find-charms]
+    permissions:
+      actions: read
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -27,40 +30,40 @@ jobs:
     name: Publish Charm (${{ matrix.charm-dir }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
-      - name: change directory
-        run: |
-          TEMP_DIR=$(mktemp -d)
-          cp -rp ./${{ matrix.charm-dir }}/. $TEMP_DIR
-          rm -rf .* * || :
-          cp -rp $TEMP_DIR/. .
-          rm -rf $TEMP_DIR
-      - name: setup lxd
-        uses: canonical/setup-lxd@v0.1.3
-      - if: github.event_name == 'push'
-        name: publish charm
-        uses: canonical/charming-actions/upload-charm@2.7.0
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
+    - uses: actions/checkout@v6.0.1
+    - name: change directory
+      run: |
+        TEMP_DIR=$(mktemp -d)
+        cp -rp ./${{ matrix.charm-dir }}/. $TEMP_DIR
+        rm -rf .* * || :
+        cp -rp $TEMP_DIR/. .
+        rm -rf $TEMP_DIR
+    - name: setup lxd
+      uses: canonical/setup-lxd@v0.1.3
+    - if: github.event_name == 'push'
+      name: publish charm
+      uses: canonical/charming-actions/upload-charm@2.7.0
+      with:
+        credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
 
   publish-charm-libs:
     name: Release charm libs
     runs-on: ubuntu-24.04
-    needs: [ publish-charm ]
+    needs: [publish-charm]
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v6.0.1
-      - name: change directory
-        run: |
-          TEMP_DIR=$(mktemp -d)
-          cp -rp ./backup_integrator_operator/. $TEMP_DIR
-          rm -rf .* * || :
-          cp -rp $TEMP_DIR/. .
-          rm -rf $TEMP_DIR
-      - uses: canonical/charming-actions/release-libraries@2.7.0
-        name: Release libs
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v6.0.1
+    - name: change directory
+      run: |
+        TEMP_DIR=$(mktemp -d)
+        cp -rp ./backup_integrator_operator/. $TEMP_DIR
+        rm -rf .* * || :
+        cp -rp $TEMP_DIR/. .
+        rm -rf $TEMP_DIR
+    - uses: canonical/charming-actions/release-libraries@2.7.0
+      name: Release libs
+      with:
+        credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.